### PR TITLE
Deploy heroku netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Live Demo
 
-[Live Demo Link Heroku](https://aristides1000.github.io/math-magicians-react/)
+[Live Demo Link Heroku](https://math-magicians-react-aristides.herokuapp.com/)
 [Live Demo Link Netlify](https://aristides1000.github.io/math-magicians-react/)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Live Demo
 
 [Live Demo Link Heroku](https://math-magicians-react-aristides.herokuapp.com/)
-[Live Demo Link Netlify](https://aristides1000.github.io/math-magicians-react/)
+[Live Demo Link Netlify](https://boring-kare-7450c1.netlify.app/)
 
 ## Getting Started
 1. Clone this repo on your local machine

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 ## Live Demo
 
-[Live Demo Link](https://aristides1000.github.io/math-magicians-react/)
+[Live Demo Link Heroku](https://aristides1000.github.io/math-magicians-react/)
+[Live Demo Link Netlify](https://aristides1000.github.io/math-magicians-react/)
 
 ## Getting Started
 1. Clone this repo on your local machine

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "math-magicians-react",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://aristides1000.github.io/math-magicians-react",
+  "homepage": "https://app.herokuapp.com/",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",


### PR DESCRIPTION
The following activities were carried out:

- [x] Use Heroku to deploy the Math Magicians app.
- [x] Use Netlify to deploy the Math Magicians app.
- [x] Add 2 links to the deployed applications (Heroku and Netlify) to the README file in your GitHub repo.